### PR TITLE
Fix timer and improve BAC calculation

### DIFF
--- a/index.html
+++ b/index.html
@@ -150,10 +150,36 @@ function restoreSession(){ try{ const j=JSON.parse(localStorage.getItem('bb_sess
 
 const ABSORB_MIN = 30;
 function absorbedStdDrinks(now){ let absorbedStd=0; for(const d of DRINKS){ const mins=(now-d.t)/60000; const f=Math.max(0,Math.min(1, mins/ABSORB_MIN)); absorbedStd += d.std * f; } return absorbedStd; }
-function bacNow(){ if(DRINKS.length===0) return 0; const now=Date.now(); const A_fl_oz = absorbedStdDrinks(now) * STD_FL_OZ; const hrs = (now - DRINKS[0].t)/3600000; const W = Math.max(80, lbs()); const r = rConst(); const b = (A_fl_oz * 5.14 / (W * r)) - beta()*hrs; return Math.max(0, b); }
+function bacNow(){
+  if(DRINKS.length===0) return 0;
+  const now = Date.now();
+  const W = Math.max(80, lbs());
+  const r = rConst();
+  let total = 0;
+  for(const d of DRINKS){
+    const mins = (now - d.t)/60000;
+    const absorbed = Math.max(0, Math.min(1, mins/ABSORB_MIN));
+    const hrs = mins/60;
+    const A = d.std * absorbed * STD_FL_OZ;
+    const contrib = (A * 5.14 / (W * r)) - beta()*hrs;
+    total += Math.max(0, contrib);
+  }
+  return Math.max(0, total);
+}
 function recalc(){ const b=bacNow(); session.peak = Math.max(session.peak||0, b); els.bac.textContent = b.toFixed(3); els.peak.textContent = session.peak.toFixed(3); els.elapsed.textContent = DRINKS.length ? fmtHM(Date.now()-DRINKS[0].t) : '0:00'; els.eta50.textContent = b<=0.05 ? 'Now' : fmtEta((b-0.05)/beta()); els.eta00.textContent = b<=0    ? 'Now' : fmtEta(b/beta()); if(els.dbg && els.dbg.parentElement.open){ const now=Date.now(); const absorbed=absorbedStdDrinks(now); const A=(absorbed*STD_FL_OZ).toFixed(3); els.dbg.textContent = `W(lb)=${lbs().toFixed(1)}  r=${rConst().toFixed(3)}  beta=${beta().toFixed(3)}%/hr\nabsorbed(std)=${absorbed.toFixed(3)}  A(fl oz ethanol)=${A}\ndrinks=${DRINKS.length}  hours=${DRINKS.length?((now-DRINKS[0].t)/3600000).toFixed(3):'0.000'}\nBAC=${b.toFixed(3)}  peak=${session.peak.toFixed(3)}`; } }
 
-function startClock(){ stopClock(); els.sessionClock.textContent = '0:00:00'; session.clockTick = setInterval(()=>{ if(!session.started || !session.t0){ els.sessionClock.textContent='0:00:00'; return; } els.sessionClock.textContent = fmtH(Date.now()-session.t0); }, 1000); }
+function startClock(){
+  stopClock();
+  function update(){
+    if(!session.started || !session.t0){
+      els.sessionClock.textContent='0:00:00';
+      return;
+    }
+    els.sessionClock.textContent = fmtH(Date.now()-session.t0);
+  }
+  update();
+  session.clockTick = setInterval(update, 1000);
+}
 function stopClock(){ if(session.clockTick) clearInterval(session.clockTick); session.clockTick=null; }
 function startRecalc(){ if(session.tick) clearInterval(session.tick); session.tick = setInterval(recalc, 1000); }
 function stopRecalc(){ if(session.tick) clearInterval(session.tick); session.tick=null; }


### PR DESCRIPTION
## Summary
- Start session now immediately launches a visible session timer
- Recalculate BAC per drink to reflect absorption and elimination of each beverage

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68baec34f4148331baf1f2b4dd2afa9e