### PR TITLE
Show immediate BAC without absorption delay

### DIFF
--- a/index.html
+++ b/index.html
@@ -148,20 +148,19 @@ function restorePrefs(){ try{ const j=JSON.parse(localStorage.getItem('bb_prefs'
 function saveSession(){ localStorage.setItem('bb_session', JSON.stringify({ started: session.started, t0: session.t0, peak: session.peak, drinks: DRINKS })); }
 function restoreSession(){ try{ const j=JSON.parse(localStorage.getItem('bb_session')||'{}'); if(j && j.started){ session.started = true; session.t0 = j.t0; session.peak = j.peak||0; DRINKS.splice(0, DRINKS.length, ...(j.drinks||[])); els.sessionState.textContent = 'Running'; els.endBtn.disabled=false; els.startBtn.disabled=true; startClock(); startRecalc(); } }catch{} }
 
-const ABSORB_MIN = 30;
-function absorbedStdDrinks(now){ let absorbedStd=0; for(const d of DRINKS){ const mins=(now-d.t)/60000; const f=Math.max(0,Math.min(1, mins/ABSORB_MIN)); absorbedStd += d.std * f; } return absorbedStd; }
+function totalStdDrinks(){ return DRINKS.reduce((s,d)=>s+d.std,0); }
 function bacNow(){
   if(DRINKS.length===0) return 0;
   const now = Date.now();
   const W = Math.max(80, lbs());
   const r = rConst();
-  const absorbed = absorbedStdDrinks(now);
-  const A = absorbed * STD_FL_OZ;
+  const total = totalStdDrinks();
+  const A = total * STD_FL_OZ;
   const hrs = (now - DRINKS[0].t)/3600000;
   const b = (A * 5.14 / (W * r)) - beta()*hrs;
   return Math.max(0, b);
 }
-function recalc(){ const b=bacNow(); session.peak = Math.max(session.peak||0, b); els.bac.textContent = b.toFixed(3); els.peak.textContent = session.peak.toFixed(3); els.elapsed.textContent = DRINKS.length ? fmtHM(Date.now()-DRINKS[0].t) : '0:00'; els.eta50.textContent = b<=0.05 ? 'Now' : fmtEta((b-0.05)/beta()); els.eta00.textContent = b<=0    ? 'Now' : fmtEta(b/beta()); if(els.dbg && els.dbg.parentElement.open){ const now=Date.now(); const absorbed=absorbedStdDrinks(now); const A=(absorbed*STD_FL_OZ).toFixed(3); els.dbg.textContent = `W(lb)=${lbs().toFixed(1)}  r=${rConst().toFixed(3)}  beta=${beta().toFixed(3)}%/hr\nabsorbed(std)=${absorbed.toFixed(3)}  A(fl oz ethanol)=${A}\ndrinks=${DRINKS.length}  hours=${DRINKS.length?((now-DRINKS[0].t)/3600000).toFixed(3):'0.000'}\nBAC=${b.toFixed(3)}  peak=${session.peak.toFixed(3)}`; } }
+function recalc(){ const b=bacNow(); session.peak = Math.max(session.peak||0, b); els.bac.textContent = b.toFixed(3); els.peak.textContent = session.peak.toFixed(3); els.elapsed.textContent = DRINKS.length ? fmtHM(Date.now()-DRINKS[0].t) : '0:00'; els.eta50.textContent = b<=0.05 ? 'Now' : fmtEta((b-0.05)/beta()); els.eta00.textContent = b<=0    ? 'Now' : fmtEta(b/beta()); if(els.dbg && els.dbg.parentElement.open){ const now=Date.now(); const total=totalStdDrinks(); const A=(total*STD_FL_OZ).toFixed(3); els.dbg.textContent = `W(lb)=${lbs().toFixed(1)}  r=${rConst().toFixed(3)}  beta=${beta().toFixed(3)}%/hr\ntotal(std)=${total.toFixed(3)}  A(fl oz ethanol)=${A}\ndrinks=${DRINKS.length}  hours=${DRINKS.length?((now-DRINKS[0].t)/3600000).toFixed(3):'0.000'}\nBAC=${b.toFixed(3)}  peak=${session.peak.toFixed(3)}`; } }
 
 function startClock(){
   stopClock();


### PR DESCRIPTION
## Summary
- remove gradual alcohol absorption, computing BAC from total drinks immediately
- update debug info to reflect new total drink logic

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68baf0b05fa0833187d38d0b8812c0f9