### PR TITLE
Use iconbb.png for app icon and header logo

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,8 @@
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover" />
 <meta name="theme-color" content="#18181d" />
+<link rel="manifest" href="manifest.json" />
+<link rel="icon" href="iconbb.png" />
 <title>Bar Buddy — BAC Estimator (Stable)</title>
 <style>
   :root{ --bg:#0d0d10; --panel:#18181d; --ink:#f5f5f7; --muted:#a5a5aa; --accent:#ffb347; --danger:#ff6b6b; }
@@ -42,7 +44,7 @@
 <body>
 <div class="app">
   <header>
-    <h1>Bar Buddy</h1>
+    <img src="iconbb.png" alt="Bar Buddy" style="height:32px" />
     <div class="muted pill">Tap drinks as you go — real-time BAC estimate</div>
   </header>
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,15 @@
+{
+  "name": "Bar Buddy",
+  "short_name": "Bar Buddy",
+  "icons": [
+    {
+      "src": "iconbb.png",
+      "sizes": "1024x1024",
+      "type": "image/png"
+    }
+  ],
+  "start_url": ".",
+  "display": "standalone",
+  "background_color": "#18181d",
+  "theme_color": "#18181d"
+}


### PR DESCRIPTION
## Summary
- Create `manifest.json` and point the app icon to `iconbb.png`
- Reference the manifest and favicon in `index.html`
- Replace the `<h1>` site title with the image logo

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bb309672588331b6d9dbca1d2af652