### PR TITLE
Handle share errors and always show fallback

### DIFF
--- a/index.html
+++ b/index.html
@@ -196,17 +196,19 @@ function restoreSession(){
   }catch{}
   els.shareBtn.disabled=session.started;
 }
-async function shareApp(){
-  const url=window.location.href;
-  if(navigator.share){
-    try{ await navigator.share({title:'Bar Buddy', url}); }catch{}
-  }else{
+  async function shareApp(){
+    const url=window.location.href;
+    if(navigator.share){
+      try{
+        await navigator.share({title:'Bar Buddy', url});
+        return;
+      }catch{}
+    }
     els.shareUrl.value=url;
     try{ await generateQR(url); }catch{}
     els.shareModal.classList.remove('hide');
     els.shareUrl.focus();
   }
-}
 async function generateQR(text){
   if(!els.qrCanvas) return;
   if(!window.QRCode){


### PR DESCRIPTION
## Summary
- Wrap `navigator.share` in try and return on success
- Always display modal/QR fallback if sharing fails or isn't supported

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bb3b6fa7e083318636f8e498a1dfa9