### PR TITLE
Handle Web Share API failure gracefully

### DIFF
--- a/index.html
+++ b/index.html
@@ -202,7 +202,9 @@ function restoreSession(){
       try{
         await navigator.share({title:'Bar Buddy', url});
         return;
-      }catch{}
+      }catch(err){
+        // fall back to manual share when Web Share API fails
+      }
     }
     els.shareUrl.value=url;
     try{ await generateQR(url); }catch{}


### PR DESCRIPTION
## Summary
- ensure shareApp falls back to manual sharing when Web Share API is unavailable or fails

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bb3dcdb578833192c58a67ad84fb06