### PR TITLE
Fix script syntax preventing button actions

### DIFF
--- a/index.html
+++ b/index.html
@@ -344,7 +344,6 @@ els.sex.addEventListener('change', ()=>{ els.rWrap.style.display=(els.sex.value=
 
 restorePrefs(); restoreSession(); recalc(); renderDrinkLog();
 
-}
 </script>
 <script>
 // Modal welcome + install prompt


### PR DESCRIPTION
## Summary
- Remove stray closing brace in inline script that halted execution and disabled app buttons

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bb436e59d4833184d957e4f0482833