### PR TITLE
Use constant elimination rate for BAC ETA

### DIFF
--- a/index.html
+++ b/index.html
@@ -327,28 +327,14 @@ function activeContribs(){
     const A = d.std * STD_FL_OZ;
     const hrs = (now - d.t)/3600000;
     const contrib = (A * 5.14 / (W * r)) - bRate*hrs;
-    if(contrib>0) arr.push({b:contrib,t:d.t,rem:contrib/bRate});
+    if(contrib>0) arr.push({b:contrib,t:d.t});
   }
   return arr;
 }
 function etaFrom(contribs, target){
   const bRate = beta();
-  if(contribs.length===0) return 0;
-  const arr=[...contribs].sort((a,b)=>a.rem-b.rem);
-  let total = arr.reduce((s,d)=>s+d.b,0);
-  let prev = 0;
-  let active = arr.length;
-  for(const c of arr){
-    const dt = c.rem - prev;
-    if(total - bRate*active*dt <= target){
-      const needed = total - target;
-      return prev + needed/(bRate*active);
-    }
-    total -= bRate*active*dt;
-    prev = c.rem;
-    active--;
-  }
-  return prev;
+  const total = contribs.reduce((s,d)=>s+d.b,0);
+  return Math.max(0, (total - target) / bRate);
 }
 function recalc(){
   const contribs = activeContribs();


### PR DESCRIPTION
## Summary
- Simplify `etaFrom` to apply a constant elimination rate and compute remaining time as `(total - target) / bRate` clamped at zero.
- Remove per-drink `rem` tracking in `activeContribs`, so ETA scales linearly with added drinks.

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node -e "function etaFrom(contribs,target){const bRate=0.015;const total=contribs.reduce((s,d)=>s+d.b,0);return Math.max(0,(total-target)/bRate);} console.log(etaFrom([{b:0.04}],0)); console.log(etaFrom([{b:0.04},{b:0.04}],0));"`


------
https://chatgpt.com/codex/tasks/task_e_68bb634200ac833194348d6a5cfe1f28